### PR TITLE
Add 'join table' for Visits

### DIFF
--- a/data.sql
+++ b/data.sql
@@ -61,3 +61,41 @@ SET owner_id = (SELECT id FROM owners WHERE full_name = 'Dean Winchester')
 WHERE name IN ('Angemon', 'Boarmon');
 COMMIT;
 
+INSERT INTO vets (name, age, date_of_graduation)
+VALUES ('William Tatcher', 45, '2000-04-23'),
+       ('Maisy Smith', 26, '2019-01-17'),
+       ('Stephanie Mendez', 64, '1981-05-04'),
+       ('Jack Harkness', 38, '2008-06-08');
+
+INSERT INTO specializations (vet_id, species_id)
+VALUES ((SELECT id FROM vets WHERE name = 'William Tatcher'), (SELECT id FROM species WHERE name = 'Pokemon'));
+
+INSERT INTO specializations (vet_id, species_id)
+VALUES ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), (SELECT id FROM species WHERE name = 'Digimon')),
+       ((SELECT id FROM vets WHERE name = 'Stephanie Mendez'), (SELECT id FROM species WHERE name = 'Pokemon'));
+
+INSERT INTO specializations (vet_id, species_id)
+VALUES ((SELECT id FROM vets WHERE name = 'Jack Harkness'), (SELECT id FROM species WHERE name = 'Digimon'));
+
+INSERT INTO visits (animal_id, vet_id, visit_date)
+VALUES
+  ((SELECT id FROM animals WHERE name = 'Agumon'), (SELECT id FROM vets WHERE name = 'William Tatcher'), '2020-05-24'),
+  ((SELECT id FROM animals WHERE name = 'Agumon'), (SELECT id FROM vets WHERE name = 'Stephanie Mendez'), '2020-07-22'),
+  ((SELECT id FROM animals WHERE name = 'Gabumon'), (SELECT id FROM vets WHERE name = 'Jack Harkness'), '2021-02-02'),
+  ((SELECT id FROM animals WHERE name = 'Pikachu'), (SELECT id FROM vets WHERE name = 'Maisy Smith'), '2020-01-05'),
+  ((SELECT id FROM animals WHERE name = 'Pikachu'), (SELECT id FROM vets WHERE name = 'Maisy Smith'), '2020-03-08'),
+  ((SELECT id FROM animals WHERE name = 'Pikachu'), (SELECT id FROM vets WHERE name = 'Maisy Smith'), '2020-05-14'),
+  ((SELECT id FROM animals WHERE name = 'Devimon'), (SELECT id FROM vets WHERE name = 'Stephanie Mendez'), '2021-05-04'),
+  ((SELECT id FROM animals WHERE name = 'Charmander'), (SELECT id FROM vets WHERE name = 'Jack Harkness'), '2021-02-24'),
+  ((SELECT id FROM animals WHERE name = 'Plantmon'), (SELECT id FROM vets WHERE name = 'Maisy Smith'), '2019-12-21'),
+  ((SELECT id FROM animals WHERE name = 'Plantmon'), (SELECT id FROM vets WHERE name = 'William Tatcher'), '2020-08-10'),
+  ((SELECT id FROM animals WHERE name = 'Plantmon'), (SELECT id FROM vets WHERE name = 'Maisy Smith'), '2021-04-07'),
+  ((SELECT id FROM animals WHERE name = 'Squirtle'), (SELECT id FROM vets WHERE name = 'Stephanie Mendez'), '2019-09-29'),
+  ((SELECT id FROM animals WHERE name = 'Angemon'), (SELECT id FROM vets WHERE name = 'Jack Harkness'), '2020-10-03'),
+  ((SELECT id FROM animals WHERE name = 'Angemon'), (SELECT id FROM vets WHERE name = 'Jack Harkness'), '2020-11-04'),
+  ((SELECT id FROM animals WHERE name = 'Boarmon'), (SELECT id FROM vets WHERE name = 'Maisy Smith'), '2019-01-24'),
+  ((SELECT id FROM animals WHERE name = 'Boarmon'), (SELECT id FROM vets WHERE name = 'Maisy Smith'), '2019-05-15'),
+  ((SELECT id FROM animals WHERE name = 'Boarmon'), (SELECT id FROM vets WHERE name = 'Maisy Smith'), '2020-02-27'),
+  ((SELECT id FROM animals WHERE name = 'Boarmon'), (SELECT id FROM vets WHERE name = 'Maisy Smith'), '2020-08-03'),
+  ((SELECT id FROM animals WHERE name = 'Blossom'), (SELECT id FROM vets WHERE name = 'Stephanie Mendez'), '2020-05-24'),
+  ((SELECT id FROM animals WHERE name = 'Blossom'), (SELECT id FROM vets WHERE name = 'William Tatcher'), '2021-01-11');

--- a/queries.sql
+++ b/queries.sql
@@ -79,3 +79,66 @@ JOIN animals ON owners.id = animals.owner_id
 GROUP BY owners.full_name
 ORDER BY animal_count DESC
 LIMIT 1;
+
+SELECT a.name
+FROM animals a
+JOIN visits v ON a.id = v.animal_id
+JOIN vets vt ON v.vet_id = vt.id
+WHERE vt.name = 'William Tatcher'
+ORDER BY v.visit_date DESC
+LIMIT 1;
+
+SELECT COUNT(DISTINCT v.animal_id) AS num_animals
+FROM visits v
+JOIN vets vt ON v.vet_id = vt.id
+WHERE vt.name = 'Stephanie Mendez';
+
+SELECT v.name, s.name AS specialty
+FROM vets v
+LEFT JOIN specializations sp ON v.id = sp.vet_id
+LEFT JOIN species s ON sp.species_id = s.id;
+
+SELECT a.name
+FROM animals a
+JOIN visits v ON a.id = v.animal_id
+JOIN vets vt ON v.vet_id = vt.id
+WHERE vt.name = 'Stephanie Mendez'
+  AND v.visit_date >= '2020-04-01'
+  AND v.visit_date <= '2020-08-30';
+
+SELECT a.name
+FROM animals a
+JOIN visits v ON a.id = v.animal_id
+GROUP BY a.id
+ORDER BY COUNT(v.*) DESC
+LIMIT 1;
+
+SELECT a.name
+FROM animals a
+JOIN visits v ON a.id = v.animal_id
+JOIN vets vt ON v.vet_id = vt.id
+WHERE vt.name = 'Maisy Smith'
+ORDER BY v.visit_date ASC
+LIMIT 1;
+
+SELECT a.name AS animal_name, vt.name AS vet_name, v.visit_date
+FROM animals a
+JOIN visits v ON a.id = v.animal_id
+JOIN vets vt ON v.vet_id = vt.id
+ORDER BY v.visit_date DESC
+LIMIT 1;
+
+SELECT COUNT(v.*)
+FROM visits v
+JOIN vets vt ON v.vet_id = vt.id
+JOIN animals a ON v.animal_id = a.id
+LEFT JOIN specializations sp ON vt.id = sp.vet_id AND a.species_id = sp.species_id
+WHERE sp.vet_id IS NULL;
+
+SELECT name, COUNT(*) AS total
+FROM (SELECT animals.species_id FROM (SELECT id FROM vets WHERE name = 'Maisy Smith') as vet
+JOIN visits ON visits.vet_id = vet.id
+JOIN animals ON animals.id = visits.animal_id) as all_visits
+JOIN species ON all_visits.species_id = species.id
+GROUP BY name 
+ORDER BY total DESC LIMIT 1;

--- a/schema.sql
+++ b/schema.sql
@@ -33,3 +33,22 @@ ADD COLUMN species_id integer REFERENCES species(id);
 ALTER TABLE animals
 ADD COLUMN owner_id integer REFERENCES owners(id);
 
+CREATE TABLE vets (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(100),
+  age INTEGER,
+  date_of_graduation DATE
+);
+
+CREATE TABLE specializations (
+  vet_id INTEGER REFERENCES vets (id),
+  species_id INTEGER REFERENCES species (id),
+  PRIMARY KEY (vet_id, species_id)
+);
+
+CREATE TABLE visits (
+  animal_id INTEGER REFERENCES animals (id),
+  vet_id INTEGER REFERENCES vets (id),
+  visit_date DATE,
+  PRIMARY KEY (animal_id, vet_id, visit_date)
+);


### PR DESCRIPTION
In this pull request, I have implemented the following changes:
- Create a table named `vets` with the following columns:
  - `id`: integer (set it as autoincremented PRIMARY KEY)
  - `name`: string
  - `age`: integer
  - `date_of_graduation`: date
- Create a "join table" called `specializations`
- Create a "join table" called `visits`
- Insert the given data into the database
- Write queries to answer the given questions
    ![Screenshot from 2023-07-15 18-04-10](https://github.com/lorenzoworx/vetClinic/assets/107998561/10d9e8ab-a9ab-4877-baeb-39763c6d7f24)
    ![Screenshot from 2023-07-15 18-04-52](https://github.com/lorenzoworx/vetClinic/assets/107998561/b1bf9695-4a66-497b-a12a-42c06f4e4387)
    ![Screenshot from 2023-07-15 18-05-45](https://github.com/lorenzoworx/vetClinic/assets/107998561/6070b185-e662-4371-a89e-1a40b752b3e9)
    ![Screenshot from 2023-07-15 18-05-52](https://github.com/lorenzoworx/vetClinic/assets/107998561/1affcdb8-f10c-47f4-bf94-b614ea17020e)

